### PR TITLE
add method NewRedisCacheURL to support AUTH command and db selection

### DIFF
--- a/init.go
+++ b/init.go
@@ -1,11 +1,16 @@
 package cache
 
 import (
+	"strings"
 	"time"
 )
 
 func InitCache(host string, idle, max int, toc, tor, tow, defaultExpiration time.Duration) {
-	Instance = NewRedisCache(host, idle, max, toc, tor, tow, defaultExpiration)
+	if strings.HasPrefix(host, "redis://") {
+		Instance = NewRedisCacheURL(host, idle, max, toc, tor, tow, defaultExpiration)
+	} else {
+		Instance = NewRedisCache(host, idle, max, toc, tor, tow, defaultExpiration)
+	}
 }
 
 func InitMemoryCache(defaultExpiration time.Duration) {

--- a/init.go
+++ b/init.go
@@ -1,16 +1,11 @@
 package cache
 
 import (
-	"strings"
 	"time"
 )
 
 func InitCache(host string, idle, max int, toc, tor, tow, defaultExpiration time.Duration) {
-	if strings.HasPrefix(host, "redis://") {
-		Instance = NewRedisCacheURL(host, idle, max, toc, tor, tow, defaultExpiration)
-	} else {
-		Instance = NewRedisCache(host, idle, max, toc, tor, tow, defaultExpiration)
-	}
+	Instance = NewRedisCache(host, idle, max, toc, tor, tow, defaultExpiration)
 }
 
 func InitMemoryCache(defaultExpiration time.Duration) {

--- a/redis.go
+++ b/redis.go
@@ -17,8 +17,6 @@ type RedisCache struct {
 // URI scheme. URLs should follow the draft IANA specification for the
 // scheme (https://www.iana.org/assignments/uri-schemes/prov/redis).
 func NewRedisCache(host string, idle, max int, toc, tor, tow, defaultExpiration time.Duration) RedisCache {
-	if strings.HasPrefix(host, "redis://") {
-	}
 	var pool = &redis.Pool{
 		MaxIdle:     idle,
 		MaxActive:   max,


### PR DESCRIPTION
Redis配置不支持密码及指定db，而github.com/garyburd/redigo提供了URL连接的方式，添加了NewRedisCacheURL方法，在初始化Cache时，如果redis配置以redis://开头，则使用URL方法
